### PR TITLE
Use `load_confounds_strategy` for simplicity

### DIFF
--- a/code/benchmark_strategies.json
+++ b/code/benchmark_strategies.json
@@ -1,84 +1,27 @@
 {
     "raw": null,
-    "highpass": {
-        "strategy" : ["high_pass"]
+    "simple": {
+        "denoise_strategy": "simple"
     },
-    "wmcsf2": {
-        "strategy" : ["high_pass", "wm_csf"],
-        "wm_csf": "basic"
-    },
-    "motion6": {
-        "strategy": ["high_pass", "motion"],
-        "motion": "basic"
-    },
-    "global1": {
-        "strategy": ["high_pass", "global_signal"],
+    "simple+gsr": {
+        "denoise_strategy": "simple",
         "global_signal": "basic"
     },
-    "motion24": {
-        "strategy": ["high_pass", "motion"],
-        "motion": "full"
+    "scrubbing": {
+        "denoise_strategy": "srubbing"
     },
-    "wmcsf2+motion6": {
-        "strategy": ["high_pass", "wm_csf", "motion"],
-        "wm_csf": "basic",
-        "motion": "basic"
-    },
-    "wmcsf2+motion6+global1": {
-        "strategy": ["high_pass", "wm_csf", "motion", "global_signal"],
-        "wm_csf": "basic",
-        "motion": "basic",
+    "scrubbing+gsr": {
+        "denoise_strategy": "srubbing",
         "global_signal": "basic"
     },
-    "wmcsf2+motion6+scrub": {
-        "strategy": ["high_pass", "wm_csf", "motion", "scrub"],
-        "wm_csf": "basic",
-        "motion": "basic",
-        "scrub": 5,
-        "fd_threshold": 0.2, 
-        "std_dvars_threshold": null
-    },
-    "wmcsf8+motion24+global4": {
-        "strategy": ["high_pass", "wm_csf", "motion", "global_signal"],
-        "wm_csf": "full",
-        "motion": "full",
-        "global_signal": "full"
-    },
-    "wmcsf8+motion24+global4+scrub": {
-        "strategy": ["high_pass", "wm_csf", "motion", "scrub"],
-        "wm_csf": "full",
-        "motion": "full",
-        "global_signal": "full",
-        "scrub": 5,
-        "fd_threshold": 0.2, 
-        "std_dvars_threshold": null
-    },
-    "acompcor": {
-        "strategy": ["high_pass", "motion", "compcor"],
-        "motion": "full",
-        "n_compcor": 5,
-        "compcor": "anat_combined"
-    },
-    "acompcor50": {
-        "strategy": ["high_pass", "motion", "compcor"],
-        "motion": "full",
-        "n_compcor": "all",
-        "compcor": "anat_combined"
-    },
-    "tcompcor": {
-        "strategy": ["high_pass", "compcor"],
-        "n_compcor": 6,
-        "compcor": "temporal"
+    "compcor": {
+        "denoise_strategy": "compcor"
     },
     "aroma": {
-        "strategy": ["high_pass", "wm_csf", "ica_aroma"],
-        "wm_csf": "basic",
-        "ica_aroma": "full"
+        "denoise_strategy": "ica_aroma"
     },
     "aroma+gsr": {
-        "strategy": ["high_pass", "wm_csf", "ica_aroma", "global_signal"],
-        "wm_csf": "basic",
-        "ica_aroma": "full",
+        "denoise_strategy": "ica_aroma",
         "global_signal": "basic"
     }
 }

--- a/code/benchmark_strategies.json
+++ b/code/benchmark_strategies.json
@@ -8,10 +8,10 @@
         "global_signal": "basic"
     },
     "scrubbing": {
-        "denoise_strategy": "srubbing"
+        "denoise_strategy": "scrubbing"
     },
     "scrubbing+gsr": {
-        "denoise_strategy": "srubbing",
+        "denoise_strategy": "scrubbing",
         "global_signal": "basic"
     },
     "compcor": {

--- a/code/process_connectomes.py
+++ b/code/process_connectomes.py
@@ -81,7 +81,7 @@ def main():
         strategy_names = [strategy_name]
 
     atlas = create_atlas_masker(atlas_name)
-    resolutions = atlas['resolutions'] if nroi is None else [nroi]
+    resolutions = atlas['resolutions'] if nroi is None else [int(nroi)]
     for nroi in resolutions:
         print(f"-- {atlas_name}: dimension {nroi} --")
         for name in strategy_names:

--- a/code/slurm_process_connectome.sh
+++ b/code/slurm_process_connectome.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-#SBATCH --job-name=schaefer
+#SBATCH --job-name=schaefer7networks
 #SBATCH --time=12:00:00
 #SBATCH --account=rrg-pbellec
-#SBATCH --output=logs/schaefer.%a.out
-#SBATCH --error=logs/schaefer.%a.err
-#SBATCH --array=0-15 
+#SBATCH --output=logs/schaefer7networks.%a.out
+#SBATCH --error=logs/schaefer7networks.%a.err
+#SBATCH --array=0-7 
 #SBATCH --cpus-per-task=1
-#SBATCH --mem=8G 
+#SBATCH --mem=4G 
 
 
 OUTPUT="/home/${USER}/projects/rrg-pbellec/${USER}/fmriprep-denoise-benchmark/inputs/"
@@ -17,5 +17,4 @@ mkdir ${OUTPUT}
 mapfile -t arr < <(jq -r 'keys[]' code/benchmark_strategies.json)
 STRATEGY=${arr[${SLURM_ARRAY_TASK_ID}]}
 echo $STRATEGY
-python ./code/process_connectomes.py ${OUTPUT} --atlas schaefer7networks --strategy-name ${STRATEGY}
-
+python ./code/process_connectomes.py ${OUTPUT} --atlas schaefer7networks --review_strategies 400 --strategy-name ${STRATEGY}

--- a/code/slurm_process_connectome.sh
+++ b/code/slurm_process_connectome.sh
@@ -17,4 +17,4 @@ mkdir ${OUTPUT}
 mapfile -t arr < <(jq -r 'keys[]' code/benchmark_strategies.json)
 STRATEGY=${arr[${SLURM_ARRAY_TASK_ID}]}
 echo $STRATEGY
-python ./code/process_connectomes.py ${OUTPUT} --atlas schaefer7networks --review_strategies 400 --strategy-name ${STRATEGY}
+python ./code/process_connectomes.py ${OUTPUT} --atlas schaefer7networks --dimension 400 --strategy-name ${STRATEGY}

--- a/code/utils/dataset.py
+++ b/code/utils/dataset.py
@@ -4,7 +4,7 @@ import pandas as pd
 from sklearn.utils import Bunch
 
 from nilearn.connectome import ConnectivityMeasure
-from nilearn.interfaces.fmriprep import load_confounds
+from nilearn.interfaces.fmriprep import load_confounds_strategy
 
 def fetch_fmriprep_derivative(participant_tsv_path, path_fmriprep_derivative,
                               specifier, space="MNI152NLin2009cAsym", aroma=False):
@@ -103,7 +103,7 @@ def deconfound_connectome_single_strategy(func_img, masker, strategy):
             subject_timeseries = masker.fit_transform(img)
 
         if parameters:
-            reduced_confounds, sample_mask = load_confounds(img, **parameters)
+            reduced_confounds, sample_mask = load_confounds_strategy(img, **parameters)
         else:
             reduced_confounds, sample_mask = None, None
 


### PR DESCRIPTION
Closes #10.

- Use `load_confounds_strategy` instead of `load_confounds`
- Remove strategies that are not applicable to real analysis.